### PR TITLE
Reimplement WaitForRoomManager check for UpdateLimiters()

### DIFF
--- a/TrueShaderAntiCrash.cs
+++ b/TrueShaderAntiCrash.cs
@@ -10,6 +10,7 @@ using MelonLoader;
 using ReMod.Core;
 using ReMod.Loader;
 using UnityEngine.SceneManagement;
+using VRC.Core;
 
 namespace ReMod.TSAC
 {
@@ -99,9 +100,23 @@ namespace ReMod.TSAC
             var loopsEnabled = category.CreateEntry("LimitLoops", true, "Limit loops");
             var geometryEnabled = category.CreateEntry("LimitGeometry", true, "Limit geometry shaders");
             var tessEnabled = category.CreateEntry("LimitTesselation", true, "Limit tesselation");
+            
+            IEnumerator WaitForRoomManagerAndUpdate()
+            {
+                while (RoomManager.field_Internal_Static_ApiWorldInstance_0 == null)
+                    yield return null;
+                UpdateLimiters();
+            }
 
             void UpdateLimiters()
             {
+                var room = RoomManager.field_Internal_Static_ApiWorldInstance_0;
+                if (room == null)
+                {
+                    MelonCoroutines.Start(WaitForRoomManagerAndUpdate());
+                    return;
+                }
+
                 _filterApi.SetFilteringState(loopsEnabled.Value, geometryEnabled.Value, tessEnabled.Value);
             }
 


### PR DESCRIPTION
In the current state of TSAC, filtering seems to reenable too quickly during world load, causing world shaders to be affected regardless.

Waiting for RoomManager to not equal null allows it to wait a little longer and seems to help resolve this issue when testing with standalone TSAC.

Also pardon if I made any errors. I can't really test a module but seems to work fine with normal TSAC. Sure, it's not the best way to handle world shaders, but at least it's better than nothing.